### PR TITLE
Update hiv_synthesis.sas

### DIFF
--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -2286,7 +2286,7 @@ end;
 
 if vmmc_disrup_covid =1 and covid_disrup_affected = 1 then prob_circ = 0;
 
-prob_circ = min(prob_circ,1);
+if prob_circ ne . then prob_circ = min(prob_circ,1);
 
 
 ***Circumcision at birth;


### PR DESCRIPTION
I had to look this up - the 'min' statement returns a missing value only if all arguments are missing.
We had prob_circ=min (prob_circ, 1). This resulted in all missing values of prob_circ being set to 1, hence everyone being circumcised in 2008 when the intervention started.