### PR TITLE
Andrew

### DIFF
--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -722,7 +722,7 @@ p_neph_stops_after_ten = 0.1;
 * effect_sw_prog_int;		e=uniform(0); if e < 0.33 then effect_sw_prog_int=0.4; if 0.33 <= e < 0.66 then effect_sw_prog_int=0.60;
 										  if e >= 0.66 then effect_sw_prog_int=0.80;
 * effect_sw_prog_adh;		e=uniform(0); if e < 0.33 then effect_sw_prog_adh=3; if 0.33 <= e < 0.66 then effect_sw_prog_adh=1.5;
-										  if e >= 0.66 then effect_sw_prog_adh=0;
+										  if e >= 0.66 then effect_sw_prog_adh=1;
 * effect_sw_prog_lossdiag;	e=uniform(0); if e < 0.33 then effect_sw_prog_lossdiag=0.80; if 0.33 <= e < 0.66 then effect_sw_prog_lossdiag=0.60;
 										  if e >= 0.66 then effect_sw_prog_lossdiag=0.40;
 * effect_sw_prog_prep;		e=uniform(0); if e < 0.33 then effect_sw_prog_prep=0.60; if 0.33 <= e < 0.66 then effect_sw_prog_prep=0.75;


### PR DESCRIPTION
Proposing a change to the range of sex behaviour transition matrices to try to include situations with a high proportion of people have less newp.  I think about 5 of the 15 alternative matrices are changed,  This was introduced in prep program in response to comments from Leigh Johnson on the fact that prep use seemed to be concentrated in a relatively small proportion of people.  This may have implications for "table 1" in 2020 which I have not looked at yet but will do so when updating the prep manuscript.

Also adding a couple more prep strategies, the ones included in the updated prep manuscript. 