### PR TITLE
Changes from walkthrough of sex worker code

### DIFF
--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -3537,7 +3537,7 @@ end;
 */
 
 
-* Reducing newp for FSW by 67% according to population change in risk behaviour;
+* Reducing newp for FSW by 50% according to population change in risk behaviour;
 if sw=1 and newp ge 1 then do;
 u=uniform(0); if u < (1-rred_rc)*rate_sw_rred_rc then do; newp=newp/3; newp=round(newp,1);end;
 end;


### PR DESCRIPTION
Leaving this here until we finish the discussion.

Changes so far:
- Updates to some comments
- Removing unused random variable
- Adding a third level of PREP uptake among sex workers (0.8 vs baseline 0.5)
- Grouping together some initialisations for sex workers at 1989
- Not resetting `age_deb_sw` to `.` after it's been set once
- Making it so a sex worker can't engage and disengage with the program within the same time step
- Change the distribution over 1-6 new partners (level 2) in 1989 to match the one used later
- Remove an `if` condition (absence of covid disruption) which is already checked
- Remove unused `act_years_sw` (#114)
- Some indentation changes

Outstanding questions:
- ~[ ] Do we need `age_deb_sw_nm` now?~ (recorded in #118 to be fixed later)
- [x] Effect of the program on PREP uptake (fine, #110)
- ~[ ] Effect of COVID disruption on program (#111)~ will be dealt with in #116
- ~[ ] Do we need `ever_sw1849_` or can it be removed completely?~ (recorded in #118 to be fixed later)