### PR TITLE
Update hiv_synthesis.sas

### DIFF
--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -4192,7 +4192,7 @@ if pop_wide_tld = 1 and registd ne 1 and ( prep_elig = 1 or ( ever_newp = 1 and 
 			r=uniform(0); if prep_willing=1 and r < prob_prep_pop_wide_tld then do ;
 
 * ts1m ; * replace line above with this:
-*			r=uniform(0); * if (prep_willing=1 or  (sw=1 and prep_willing_sw=1 )) and r < ( 1 - (1 - prob_prep_pop_wide_tld)**(1/3) ) then do ;
+*			r=uniform(0); * if prep_willing=1 and r < ( 1 - (1 - prob_prep_pop_wide_tld)**(1/3) ) then do ;
 
 			prep   =1; pop_wide_tld_prep=1;  prep_ever=1; dt_prep_s=caldate{t}; dt_prep_e=caldate{t};
 			end;


### PR DESCRIPTION
PrEP uptake was higher amongst sex workers than non-sex workers, irrespective of whether or not a sex worker program was in place. Andrew and I discussed this earlier today and propose to have the same level of PrEP for all people when a sex worker program is NOT in place (this is close to zero before 2020). This is under the assumption that being a sex worker does not necessarily mean better access to PrEP, whilst a program being in place would mean that. In the context of a program, we think access to PrEP should be quite high, so have suggested quite high values here, but these may change depending on discussions at the AMETHIST meeting.