### PR TITLE
More changes from walkthrough of sex worker code

### DIFF
--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -1932,7 +1932,7 @@ sw_tm2=sw_tm1;
 
 tested_tm1=tested; tested=0;
 ep_tm1=ep;
-newp_tm1=newp; newp = .;
+if t > 1 then do; newp_tm1=newp; newp = .; end;
 np_tm1=np; np = .;
 registd_tm1 = registd; 
 onart_tm1=onart;


### PR DESCRIPTION
This is a delayed set of changes, some of them addressing issues we identified and others rewriting the code to (hopefully) make it clearer.

It may be easier to look at each individual commit separately, or we could also discuss it on the call.

Summary:
- Remove unused variables (fixes #118)
- Change `newp_tm1` for new sex workers so it covers all levels (fixes #115)
- Fix `newp` level 2 to always start at 7 as intended
- Rewrite initial `newp` assignment and transitions between `newp` levels to avoid repetition
- Rewrite calculation of probability to become a sex worker so the different factors are clearer and modifications are easier