### PR TITLE
Macro for sampling values

### DIFF
--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -521,11 +521,10 @@ p_neph_stops_after_ten = 0.1;
 * ========== PARAMETER VALUES SAMPLED ;  * these represent both uncertainty over likely fixed biological parameters and variability over settings;
 
 ***** population growth  ***LBM Jul19;
-* inc_cat; r=uniform(0); if r < 0.33 then inc_cat = 1; if 0.33 <= r < 0.66 then inc_cat = 2; if 0.66 <= r then inc_cat=3;
+* inc_cat; %sample(inc_cat, 1 2 3, 0.33 0.33 0.34);
 
 ***** Sexual behaviour;
-* base_rate_sw; r=uniform(0);  if  r < 0.20 then base_rate_sw = 0.0015;  if 0.20 <= r < 0.8 then base_rate_sw = 0.002 ; 
-								if 0.80 <= r then base_rate_sw = 0.0025 ;  
+* base_rate_sw; %sample(base_rate_sw, 0.0015 0.002 0.0025, 0.20 0.60 0.20);
 
 
 * dependent_on_time_step_length ;


### PR DESCRIPTION
This adds a new macro for sampling values from a weighted discrete distribution.
It can be used to replace code of the form
```sas
r=uniform(0); if r < 0.4 then val = 1; if 0.4 <= r < 0.6 then val = 2; if 0.6 <= r then val=3;
```

with
```sas
%sample(val, 1 2 3, 0.4 0.2 0.4)
```

The big difference from the previous format is that this macro should be given the probability/mass for each value, rather than the cumulative probability "up to" that point.

Note that:
- the possible values (`1 2 3`) are separated by spaces
- their probabilities (`0.4 0.2 0.4`) are separated by spaces
- these two lists are separated by a comma

The documentation comment above the macro includes this information as well as an example. It has also been introduced in two places in the file, to demonstrated its usage.

All these examples concern a choice between 3 values but that is a coincidence - the macro can be used for any number of values.