### PR TITLE
Update PrEP adherence for <25s compared to >25s

### DIFF
--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -2471,7 +2471,7 @@ end;
 
 * pop_wide_tld_2020;	
 if pop_wide_tld_2020 = 1 then do;
-	pop_wide_tld = 1; prep_strategy = 13; prob_prep_pop_wide_tld = 0.10; 
+	pop_wide_tld = 1; prep_strategy = 4; prob_prep_pop_wide_tld = 0.10; 
 	higher_future_prep_cov = 0;  * this is instead of current type of prep program;
 end;
 
@@ -3937,7 +3937,7 @@ if t ge 2 and (registd ne 1) and hard_reach=0 then do;
 		(newp ge 1 or (epdiag=1 and epart ne 1) or (registd ne 1 and ep=1 and epart ne 1 and (r < 0.05 or (r < 0.5 and epi=1)))) then prep_elig=1; 
 	end;
 
-	if prep_strategy=13 then do;
+	if prep_strategy=4 then do;		* previously prep_strategy 13 *Apr2021
     	r = rand('Uniform');
       	if (newp ge 1 or (epdiag=1 and epart ne 1) or 
       	(gender=2 and 15 <= age < 50 and registd ne 1 and ep=1 and epart ne 1 and (r < 0.05 or (r < 0.5 and epi=1))) ) then prep_elig=1; 


### PR DESCRIPTION
As discussed before Easter, I've changed around the way PrEP adherence is assigned for older vs younger people. In the new version, the value 'adh' is used for all adults, and then it's adjusted by factor 'rel_prep_adh_younger' for 50% of <25s (currently set to 0.7). This was previously done the other way round. 

This will result in overall lower adherence than the previous method so I am wondering if we want to adjust the distribution values assigned to 'adhav_pr' to compensate for this. I've made a suggestion here (lines 1807-12) with completely arbitrary numbers but we should discuss. 

I've put this in a separate pull request so it doesn't get muddled up with the bigger one incorporating the 'sample' macro. 

Fixes issue #119.