### PR TITLE
Replace random functions

### DIFF
--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -4924,7 +4924,7 @@ end;
 * risk of infected partner per new partner;
 nip=0;
 if risk_nippnp*newp > 0 then do;
-	nip = min(ranpoi(0,risk_nippnp*newp),newp);
+	nip = min(rand('poisson',risk_nippnp*newp),newp);
 end;
 
 
@@ -5039,7 +5039,7 @@ of transmission.  if so, the tr_rate_primary should be lowered;
                 * resistance virus in partner - tams;
                 t_prop_tam = t_prop_tam1+t_prop_tam2+t_prop_tam3;
                 g=rand('uniform');
-                if g < t_prop_tam  then  do; tam_p=max(1,ranpoi(0,1)); if tam_p ge 6 then tam_p=6;end;
+                if g < t_prop_tam  then  do; tam_p=max(1,rand('poisson',1)); if tam_p ge 6 then tam_p=6;end;
 
 				* resistance virus in partner - 184m;
 				g=rand('uniform');
@@ -5212,7 +5212,7 @@ if epi=1 then do;  * dependent_on_time_step_length ;
                 * resistance virus in partner - tams;
                 t_prop_tam = t_prop_tam1+t_prop_tam2+t_prop_tam3;
                 g=rand('uniform');
-                if g < t_prop_tam  then  do; tam_p=max(1,ranpoi(0,1)); if tam_p ge 6 then tam_p=6;end;
+                if g < t_prop_tam  then  do; tam_p=max(1,rand('poisson',1)); if tam_p ge 6 then tam_p=6;end;
 
 				* resistance virus in partner - 184m;
 				g=rand('uniform');


### PR DESCRIPTION
This uses the newer `rand` function for generating random variables. Before, the code was using a mixture of that and some older-style functions (`uniform`, `normal`, `ranpoi`).

The advantages of the newer style are mainly:
- it's simpler to specify parameters of the distribution. For example, we can generate a uniform variable with support [-5, 5] as `rand('uniform', -5, 5)` rather than `-5  + 10 * uniform(0)` (although no such changes have been made in the code yet).
- it's possible to set the seed once in each data step, and then all the functions in that step will use the same sequence, making it easier (in principle!) to reproduce the results.

See also: more [information on the differences](https://amadeus.co.uk/tips/why-is-the-rand-function-better-than-ranuni-and-rannor/) and a [recommendation from SAS to use the newer function](https://documentation.sas.com/doc/en/pgmsascdc/9.4_3.5/lefunctionsref/p026ygl6toz3tgn14lt4iu6cl5bb.htm#n1f6xjwxagmp94n1hporgf7dqug6).