### PR TITLE
Clean up some sum variables

### DIFF
--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -14770,7 +14770,7 @@ if 15 <= age      and (death = . or caldate&j = death ) then do;
 	s_o_ten_tox + o_ten_tox ; s_o_taz_tox + o_taz_tox ; s_o_lpr_tox + o_lpr_tox ; s_o_efa_tox + o_efa_tox ; s_o_nev_tox + o_nev_tox ; 
    	s_o_dol_tox + o_dol_tox ; s_o_zdv_adh_hi + o_zdv_adh_hi ; s_o_3tc_adh_hi + o_3tc_adh_hi ; s_o_ten_adh_hi + o_ten_adh_hi ;
     s_o_taz_adh_hi + o_taz_adh_hi ; s_o_lpr_adh_hi + o_lpr_adh_hi ; s_o_efa_adh_hi + o_efa_adh_hi ; s_o_nev_adh_hi + o_nev_adh_hi ; s_o_dol_adh_hi + o_dol_adh_hi ; 
- 	s_o_tle_tox + o_tle_tox ; s_o_tld_tox = o_tld_tox ; s_o_zld_tox + o_zld_tox ; s_o_zla_tox + o_zla_tox ; s_o_tle_adh_hi + o_tle_adh_hi ;
+ 	s_o_tle_tox + o_tle_tox ; s_o_tld_tox + o_tld_tox ; s_o_zld_tox + o_zld_tox ; s_o_zla_tox + o_zla_tox ; s_o_tle_adh_hi + o_tle_adh_hi ;
     s_o_tld_adh_hi + o_tld_adh_hi ; s_o_zld_adh_hi + o_zld_adh_hi ; s_o_zla_adh_hi + o_zla_adh_hi ; s_a_zld_if_reg_op_116 + a_zld_if_reg_op_116 ;   
     s_adh_hi_a_zld_if_reg_op_116 + adh_hi_a_zld_if_reg_op_116 ; s_nac_ge2p75_a_zld_if_reg_op_116 + nac_ge2p75_a_zld_if_reg_op_116 ;   
 	s_nac_ge2p00_a_zld_if_reg_op_116 + nac_ge2p00_a_zld_if_reg_op_116 ; s_nac_ge1p50_a_zld_if_reg_op_116 + nac_ge1p50_a_zld_if_reg_op_116 ;


### PR DESCRIPTION
I found a few variables which were either defined twice, or listed twice in the same `keep` statement. The latter probably has no effect, but I think it's cleaner to only have them once.

Many of these are variables that could fall under two "categories": for example, should `s_diag_sw` be with the other diagnosed variables or with the sex worker ones? I have tried to be consistent with where to leave them, but perhaps they are better placed in the other section.

I think some were mistakes, which I have tried to fix. For example:
- `s_dead_cvd_ge80` is now replaced with `s_dead_cvd_ge80m` and `s_dead_cvd_ge80w`, to match the other age groups
- `s_year_4_infection` was not defined but `s_year_5_infection` was defined twice
- `s_line1_lf1` defined twice, accidentally?

There are still two sum variables which are defined twice, both for all living people over 15 and all people over 15 (including dead):
- `s_cost_child_hiv_mo_art`
- `s_cost_child_hiv`

I believe it will be better to put the variable lists in a separate file to be `%include`d. This would avoid the repetition in the main model, and make it easier to check for issues like this in the future.