### PR TITLE
Handle non-ASCII characters in file during checks

### DIFF
--- a/tests/test_sas_code.py
+++ b/tests/test_sas_code.py
@@ -47,7 +47,7 @@ def validate_text(text):
 
 
 if __name__ == "__main__":
-    with open('hiv_synthesis.sas') as model_file:
+    with open('hiv_synthesis.sas', encoding='latin1') as model_file:
         model_text = model_file.read()
     errors = validate_text(model_text)
     if errors:


### PR DESCRIPTION
This came up in the discussion today by @andrew-phillips-1.

Sometimes the model comments include characters that are not valid ASCII, particularly quotes and apostrophes copied from PDFs. This can cause failures in the tests when pushing to GitHub.

With this change, we use a more "permissive" text encoding (at least for the Latin alphabet), which should be able to handle these characters in the automatic checks without failing. This change  does not affect the model itself, only affects the tests that run on GitHub.