### PR TITLE
Record merged PRs in the new repository

### DIFF
--- a/.github/workflows/merged_pr.yaml
+++ b/.github/workflows/merged_pr.yaml
@@ -2,6 +2,8 @@
 # are also tracked in the new repository, so they can be included as
 # the Python model is developed.
 # The changes are recorded in https://github.com/UCL/hivpy/issues/95.
+# For this to run, it requires a secret named PAT_FOR_ISSUE to exist in hiv-modelling.
+# The secret should hold a personal access token with enough permissions to update issue comments in hivpy.
 name: Record merged PRs in the Python repository
 
 on:


### PR DESCRIPTION
This change makes it so that, whenever a pull request is merged on this repository, [an issue in the new repository](https://github.com/UCL/hivpy/issues/95) will be automatically updated to record that.

This will make it easier to keep track of changes in the SAS code while the Python model is being developed.

More technical notes: In order for this to run, it needs a personal access token with enough permissions to modify the issue comments in hivpy. The token should be stored as a secret in this repository (I have used the name `PAT_FOR_ISSUE` here). I have created one such token under my account and stored it in this repository, but it will expire on December 31, and my access may lapse before then anyway! Therefore, someone else will need to create a new one, and update the value of the secret.