### PR TITLE
Adding date1test to prep code

### DIFF
--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -4570,7 +4570,7 @@ and ((testing_disrup_covid ne 1 or covid_disrup_affected ne 1 )) then do;
 			if unitest < rate_1sttest then do;
 				newp_lasttest=0;
 				tested=1; 
-				if ever_tested ne 1 then date1test=caldate{t}; ever_tested=1; dt_last_test=caldate{t}; 
+				date1test=caldate{t}; ever_tested=1; dt_last_test=caldate{t}; 
 				np_lasttest=0; newp_lasttest_tested_this_per=newp_lasttest; newp_lasttest=0;
 			end;
 		end;


### PR DESCRIPTION
I noticed from Vale's pull request that date1test is not defined in the section about testing to start PrEP. I've added it in there, but also checked all the different testing places and there were a few other things that weren't consistent. So I've tried to make them all the same - so every time testing happens, I've put all the various testing-related variables (where applicable) in this order:

```
tested=1;  tested_specific_reason=1;
if ever_tested ne 1 then date1test=caldate{t}; ever_tested=1; dt_last_test=caldate{t}; 
np_lasttest=0; newp_lasttest_tested_this_per=newp_lasttest; newp_lasttest=0;
```

There's no rush to merge this but perhaps we can discuss together. Or if you have time, please could you have a look through and check that they make sense? In particular, I can see that the second line won't be relevant when someone is explicitly retesting so I have omitted in some places, but is the last line needed every time someone tests?