### PR TITLE
Update country-specific sections

### DIFF
--- a/Malawi_parameters.sas
+++ b/Malawi_parameters.sas
@@ -3,21 +3,25 @@
 /***************************************************************************/
 
 
+* country;					country='Malawi';
+* caldate1;					caldate1 = 1984;		*core: 1989;
+* caldate_never_dot;		caldate_never_dot=1984;	*core: 1989;
+
 * POPULATION GROWTH AND DEMOGRAPHY;
 
-* inc_cat; 					 inc_cat = 1 ;  
+* inc_cat; 					 inc_cat = 4 ;  	* Changed to new inc_cat 4 (specified for Zim) from inc_cat 1 JAS Nov23;
 
 * SEXUAL BEHAVIOUR;
 
-* ych_risk_beh_newp;        %sample(ych_risk_beh_newp, 0.5 0.6 0.7 , 0.4 0.3 0.3); 
-* ych_risk_beh_ep;          %sample_uniform(ych_risk_beh_ep, 0.8 0.9 0.95);
-* p_rred_p;                 %sample_uniform(p_rred_p, 0.4 0.5 0.6);
-* p_hsb_p;                  %sample(p_hsb_p, 0.05 0.08 0.15 0.25, 0.25 0.25 0.25  0.25);
-* newp_factor;              %sample_uniform(newp_factor, 1 2 3 5 ); 
-
-* ych2_risk_beh_newp;       %sample(ych2_risk_beh_newp,
-                                0.95    0.99    1   ,
-                                0.3     0.3     0.4   );
+/** ych_risk_beh_newp;        %sample(ych_risk_beh_newp, 0.5 0.6 0.7 , 0.4 0.3 0.3); */
+/** ych_risk_beh_ep;          %sample_uniform(ych_risk_beh_ep, 0.8 0.9 0.95);*/
+/** p_rred_p;                 %sample_uniform(p_rred_p, 0.4 0.5 0.6);*/
+/** p_hsb_p;                  %sample(p_hsb_p, 0.05 0.08 0.15 0.25, 0.25 0.25 0.25  0.25);*/
+/** newp_factor;              %sample_uniform(newp_factor, 1 2 3 5 ); */
+/**/
+/** ych2_risk_beh_newp;       %sample(ych2_risk_beh_newp,*/
+/*                                0.95    0.99    1   ,*/
+/*                                0.3     0.3     0.4   );*/
 
 * HIV TESTING;
 

--- a/SA_parameters.sas
+++ b/SA_parameters.sas
@@ -1,3 +1,8 @@
+* These parameters are up to date at 17th Oct 2023;
+* caldate1, caldate_never_dot and startyr specified here to overwrite core value;
+* country added to switch on SA-spcific abort statements;
+* Note that rate_anc_inc has been updated from rate_testanc_inc (used in some other SA analyses) to be consistent with the current core program;
+* JAS Oct23;		
 
 ****% on ART of those diag too high***
 
@@ -6,6 +11,9 @@
 ******************     SOUTH AFRICA SPECIFIC PARAMETERS    ******************
 /***************************************************************************/
 
+* country;					country='South Africa';
+* caldate1;					caldate1 = 1984;		*core: 1989;
+* caldate_never_dot;		caldate_never_dot=1984;	*core: 1989;
 
 * POPULATION GROWTH AND DEMOGRAPHY;
 * inc_cat; 					inc_cat = 3;
@@ -14,7 +22,9 @@
 
 * fold_change_ac_death_rate;fold_change_ac_death_rate_w = 0.65; fold_change_ac_death_rate_m = 0.65; 
 
-newp_seed = 10 ;
+* INTRODUCTION OF HIV;
+* startyr;					startyr = 1993;
+* newp_seed;				newp_seed = 10 ;
 
 * SEXUAL BEHAVIOUR;
 * ych_risk_beh_newp;  		ych_risk_beh_newp = 1;
@@ -29,6 +39,8 @@ newp_seed = 10 ;
 
 * sex_age_mixing_matrix_m;	%sample(sex_age_mixing_matrix_m, 1 2 3 4 5 6 , 0.1 0.1 0.1 0.1 0.1 0.5);
 * sex_age_mixing_matrix_w;	%sample(sex_age_mixing_matrix_w, 1 2 3 4 5 6 , 0.3 0.3 0.1 0.1 0.1 0.1);
+
+
 
 
 * TRANSMISSION;

--- a/Zim_parameters.sas
+++ b/Zim_parameters.sas
@@ -2,14 +2,15 @@
 ******************     ZIMBABWE SPECIFIC PARAMETERS    ******************
 /***************************************************************************/
 
+* country;					country='Zimbabwe';
+* caldate1;					caldate1 = 1984;		*core: 1989;
+* caldate_never_dot;		caldate_never_dot=1984;	*core: 1989;
 
 * POPULATION GROWTH AND DEMOGRAPHY;
-caldate1=1984;
-caldate_never_dot=1984;
-startyr = 1991 + 0.25;
+* inc_cat; 					inc_cat = 4 ;  
 
-* inc_cat; 					 inc_cat = 4 ;  
-
+* INTRODUCTION OF HIV;
+* startyr;					startyr = 1991 + 0.25;
 
 * HIV TESTING;
 

--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -128,6 +128,7 @@ run = rand('uniform')*1000000000;  run=round(run,1);
 dataset_id=trim(left(run));
 call symput('dataset_id',dataset_id);
 
+* overwritten in country-specific include statements (SA, Zim, MW) JAS Feb24;
 caldate1=1989;
 caldate_never_dot=1989;
 

--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -144,7 +144,7 @@ _u57 = rand('uniform'); _u58 = rand('uniform'); _u59 = rand('uniform'); _u60 = r
 
 
 * start of epidemic;
-startyr = 1989 + 0.25;
+startyr = 1989 + 0.25;		* overwritten in country-specific include statements (SA, Zim) JAS Feb24;
 * ts1m;
 /*
 startyr = 1989 + 1/12;
@@ -3088,8 +3088,10 @@ if caldate{t} >= &year_interv then do;
 end;
 
 if testing_disrup_covid =1 and covid_disrup_affected = 1 then do; rate_1sttest = 0 ; rate_reptest = 0; end;
-***Zim specific; 
-/*if 2020.5 le caldate{t} lt 2021.5 then do; rate_1sttest=rate_1sttest*0.5;rate_reptest=rate_reptest*0.5;end;*/
+***Zim specific;	* JAS Feb24;
+if country = 'Zimbabwe' then do;
+	if 2020.5 le caldate{t} lt 2021.5 then do; rate_1sttest=rate_1sttest*0.5;rate_reptest=rate_reptest*0.5;end;
+end;
 
 
 * ts1m;
@@ -3202,9 +3204,11 @@ if t ge 2 and &year_interv <= caldate{t} and circ_inc_rate_year_i = 4 then do;*o
     end;
 end;
 
-***Zim specific; 
-/*if 2020.5 le caldate{t} lt 2021.5 then prob_circ = prob_circ*0.5;*/
-/*if vmmc_disrup_covid =1 and covid_disrup_affected = 1 then prob_circ = 0;*/
+***Zim specific;	*JAS Feb24;
+if country = 'Zimbabwe' then do;
+	if 2020.5 le caldate{t} lt 2021.5 then prob_circ = prob_circ*0.5;
+	if vmmc_disrup_covid =1 and covid_disrup_affected = 1 then prob_circ = 0;
+end;
 
 
 if prob_circ ne . then prob_circ = min(prob_circ,1);
@@ -17554,7 +17558,7 @@ hiv_cab = hiv_cab_3m + hiv_cab_6m + hiv_cab_9m + hiv_cab_ge12m ;
 
 /*
 
-proc freq; tables cald hiv ; where death=.; run;
+proc freq; tables country cald hiv ; where death=.; run;
 
 */
 
@@ -19173,13 +19177,32 @@ keep_going_1999   keep_going_2004   keep_going_2016   keep_going_2020
 
 ;
 
-***Zim specific;
-/*
-if cald = 1999.5 and (prevalence1549 < 0.08) then do; abort abend; end;
-if cald = 2004.5 and (prevalence1549 < 0.07) then do; abort abend; end;
-if cald = 2015.5 and (prevalence1549 < 0.12  or prevalence1549 > 0.15 ) then do; abort abend; end;*ZIMPHIA 13.4;
-*/
-/*if cald = &year_interv and (prevalence1549 > 0.30  or incidence1549 < 0.15 ) then do; abort abend; end;*/
+***Malawi specific;			*JAS Feb24;
+if country = 'Malawi' then do;
+	if cald = 1998.5 and (prevalence1549 < 0.08  or prevalence1549 > 0.19 ) then do; abort abend; end;
+	if cald = 1999.5 and (prevalence1549 < 0.08  or prevalence1549 > 0.19 ) then do; abort abend; end;
+	if cald = 2004.5 and (prevalence1549 < 0.07  or prevalence1549 > 0.20 ) then do; abort abend; end;
+	if cald = 2016.5 and (prevalence1549 < 0.07  or prevalence1549 > 0.13 ) then do; abort abend; end;
+	if cald = 2020 and p_vl1000 < 0.75 then do; abort abend; end;
+end;
+
+***South Africa specific;	*JAS Feb24;
+if country = 'South Africa' then do;
+	if cald = 2017.5 and (prevalence1549 < 0.166 or prevalence1549 > 0.246) then do;
+	  abort abend;
+	end;
+	if cald = 2021 and (s_onart < 3333 or s_onart > 6400) then do;
+	  abort abend;
+	end;
+end;
+
+***Zim specific;			*JAS Feb24;
+if country = 'Zimbabwe' then do;
+	if cald = 1999.5 and (prevalence1549 < 0.08) then do; abort abend; end;
+	if cald = 2004.5 and (prevalence1549 < 0.07) then do; abort abend; end;
+	if cald = 2015.5 and (prevalence1549 < 0.12  or prevalence1549 > 0.15 ) then do; abort abend; end;*ZIMPHIA 13.4;
+end;
+/*if cald = &year_interv and (prevalence1549 > 0.30  or incidence1549 < 0.15 ) then do; abort abend; end;*/	*QUERY should we be using this line for Zim? JAS Feb24;
 
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;


### PR DESCRIPTION
- Define 'country' in the country-specific include files 
- Define caldate1, caldate_never_dot and start_yr in the include files
- Make the country-specific calibration sections dependent on parameter 'country'. If no include statement is run then country will be . so these sections will not run.
- Updated to latest MW parameters, although these may yet change.