### PR TITLE
Replacing MIHPSA options and self-testing code in core

### DIFF
--- a/hiv_synthesis.sas
+++ b/hiv_synthesis.sas
@@ -363,13 +363,30 @@ newp_seed = 7;
 								2011.5 	2013.5 	2015.5 	2017.5 	2019.5, 
 								0.1 	0.1 	0.2 	0.3 	0.3);
 
-*% fold_rate_decr_test_future; %sample_uniform(fold_rate_decr_test_future, 0.25 0.33 0.5);
+* fold_rate_decr_test_future; %sample_uniform(fold_rate_decr_test_future, 0.25 0.33 0.5);
 
 							* dependent_on_time_step_length ;
 * incr_test_rate_sympt; 	%sample_uniform(incr_test_rate_sympt, 1.05 1.10 1.15 1.20 1.25);
 							* dependent_on_time_step_length ;
 
 * rr_testing_female;		rr_testing_female=1.5;
+
+* prob_self_test_hard_reach;prob_self_test_hard_reach = 0;
+
+* self_test_targeting;		self_test_targeting = test_targeting;
+
+* rate_self_test;			rate_self_test = 0;
+
+* self_test_sens;			self_test_sens = 0.93;          
+
+* prob_pos_self_test_conf;	prob_pos_self_test_conf = 0.8;
+
+* secondary_dist_self_test;		secondary_dist_self_test = 0; 
+* intervention in place to give to sexual partners ;
+
+* secondary_self_test_targeting; secondary_self_test_targeting = 1;
+
+
 
 * LINKAGE, RETENTION, MONITORING, LOSS, RETURN, INTERRUPTION OF ART AND RESTARTING, ART;
 
@@ -1756,8 +1773,10 @@ eff_prob_lossdiag_adctb = prob_lossdiag_adctb ;
 eff_prob_return_adc = prob_return_adc ;
 
 * define effective test_targeting;
-
 eff_test_targeting = test_targeting;
+
+* define effective self_test_targeting;
+eff_self_test_targeting = self_test_targeting;
 
 * define eff_prob_birth_circ;
 eff_prob_birth_circ=prob_birth_circ;
@@ -2087,6 +2106,7 @@ onart_tm2=onart_tm1;
 sw_tm2=sw_tm1; 
 
 tested_tm1=tested; tested=0;
+self_tested_tm1=self_tested; self_tested=0;
 visit_hypertension_tm1 = visit_hypertension;
 tested_bp_tm1 = tested_bp;
 sbp_m_tm1 = sbp_m;
@@ -2138,6 +2158,269 @@ agyw=0;	if gender=2 and 15<=age<25 then agyw=1;		* MIHPSA JAS Jul23;
 * INTERVENTIONS / CHANGES in year_interv ;
 
 option = &s;
+mihpsa_params_set_in_options=0;				* JAS Oct23;
+
+if caldate_never_dot >= &year_interv then do;
+* we need to use caldate_never_dot so that the parameter value is given to everyone in the data set - we use the value for serial_no = 100000
+who may be dead and hence have caldate{t} missing;
+
+ 	*Option 0 is continuation at current rates;
+ 	*Option 1 is essential scenario for Zimbabwe;
+	*Option 2,3,4,5,6,7    are essential + 1 testing strategy;						 *Vale;
+	*Option 10,11,12,13,14 are essential + different prevention strategies;			 *Jenny;
+	*Option 15,16,17,18    are essential + Oral TDF/FTC PrEP for different sub-pops; *Jenny;
+	*Option 19,20,21,22    are essential + Dapivirine ring   for different sub-pops; *Jenny;
+	*Option 23,24,25,26    are essential + Injectable PrEP   for different sub-pops; *Jenny;
+	*Option 30,31,32,33,34 are essential + Linkage, management, ART Interv;			 *Andrew;	
+	*Option 40			   is  essential + DREAMS;									 *Vale;
+
+
+
+	if option in (1 2 3 4 5 6 7 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 31 32 33 34 40) then do;
+	*MINIMAL;
+
+		mihpsa_params_set_in_options=1;		* Marker to prevent MIHPSA parameters from being overwritten JAS Oct23;
+
+		*Testing;
+		incr_test_year_i = 4;			*No testing in the general population;
+		eff_sw_program = 0;		 			*No SW program;
+		*Note: at the moment the other testing modalities to be swicthed off are not modelled;
+
+		*Prevention;
+		*Condom promotion and provision: currently not in essential scenario but under discussion;
+		*SBCC: not explicitly modelled, but the switch off is;
+		*condom_incr_year_i=2;    		*Switches off SBCC;
+		circ_inc_rate_year_i = 2;		*No VMMC;
+
+		*Prep;
+		prep_any_strategy=0;
+		date_prep_oral_intro=2100;
+		date_prep_inj_intro=2100;
+		date_prep_vr_intro=2100;
+		eff_rate_test_startprep_any=0;
+		eff_prob_prep_oral_b=0;
+		eff_prob_prep_inj_b=0; 
+		eff_prob_prep_vr_b=0;
+		eff_rate_choose_stop_prep_oral=1;
+		eff_rate_choose_stop_prep_inj=1;
+		eff_rate_choose_stop_prep_vr=1;
+		eff_prob_prep_any_restart_choice=0;	
+
+		*Linkage, management, ART Interv;
+		*PCP is part of the essential scenario;
+		absence_cd4_year_i = 1;				*If CD4 and VL are both not available clinical monitoring is assumed;
+		absence_vl_year_i = 1; 				*If VL is not available, but CD4 is, still clinical monitoring is assumed, CD4 is measured at first visit when naive and then every 6 months;
+		crag_cd4_l200=0;					*Switch off for screening for Cryptococcal disease;
+		tblam_cd4_l200=0;
+		*VL monitoring is switched off as clinical monitoring is assumed;
+		*POC CD4: not modelled yet?;
+		*POC VL: not modelled yet?;
+		poc_vl_monitoring_i=0;
+
+		*DREAMS: ok to assume that is has not been included so far?;
+	end;
+
+
+	*TESTING;
+	*TESTING;
+	if option = 2 then do; *Self-test kits distributed (Primary distribution);
+		prob_self_test_hard_reach = 0.1;
+		self_test_targeting = 1.5;
+		rate_self_test = 0.03;
+	end;
+	if option = 3  then do; *Self-test kits distributed (Secondary distribution, excluding for partners) [S2];
+	end;
+	if option = 4 then do; *Self-test kits distributed (Secondary distribution, for sexual partners) [S3];
+		* values suggest lower amounts of tests but perhaps better targeted at recent sexual risk and perhaps getting more at hard to reach ;
+		prob_self_test_hard_reach = 0.2;
+		self_test_targeting = 2.0;
+		rate_self_test = 0.01;
+		secondary_dist_self_test = 1; secondary_self_test_targeting = 3;
+	end;
+	if option = 5 then do; *Clients tested for HIV at facility, excluding ANC & PD, infant testing, contacts testing for HIV at the facility and testing of FSW ;
+	end;
+	if option = 6 then do; *Contacts tested for HIV at the facility [B11];
+	end;
+	if option = 7 then do; *Testing program for FSW;
+	end;
+
+	*PREVENTION;
+	if option = 10 then do;*HIV P&T program targeting FSWf;
+	end;
+	if option = 11 then do;*Social and behavioral change communication (SBCC);
+	end;
+	if option = 12 then do;*Increase in Condom use promotion and provision;
+	end;
+	if option = 13 then do;*General population mens health clinics (for men from the general population);
+	end;
+	if option = 14 then do;*VMMC in 15-49 years old;
+	end;
+
+	*PrEP interventions;	*JAS Apr2023 and Oct23;
+	*option 15: Oral TDF/FTC PrEP for AGYW;	
+	*option 16: Oral TDF/FTC PrEP for FSW;	
+	*option 17: Oral TDF/FTC PrEP for sero-discordant couples (SDC);	
+	*option 18: Oral TDF/FTC PrEP for pregnant and breastfeeding women (PLW);	
+	*option 19: Dapivirine ring for AGYW;	
+	*option 20: Dapivirine ring for FSW;	
+	*option 21: Dapivirine ring for sero-discordant couples (SDC);	
+	*option 22: Dapivirine ring for pregnant and breastfeeding women (PLW);	
+	*option 23: Injectable PrEP for AGYW;	
+	*option 24: Injectable PrEP for FSW;	
+	*option 25: Injectable PrEP for Sero-discordant couples (SDC);	
+	*option 26: Injectable PrEP for pregnant and breastfeeding women (PLW);
+
+	if option in (15 19 23) then prep_any_strategy=3;		* All PrEP options for AGYW;
+	if option in (16 20 24) then prep_any_strategy=2;		* All PrEP options for FSW;
+	if option in (17 21 25) then prep_any_strategy=15;		* All PrEP options for SDC;
+	if option in (18 22 26) then prep_any_strategy=16;		* All PrEP options for PLW;
+
+	* All oral PrEP options;
+	if option in (15 16 17 18) then do;
+		date_prep_oral_intro=&year_interv;
+		if caldate{t}=&year_interv then do;
+			pref_prep_oral_beta_s1=pref_prep_oral_beta_s1*3;		* From Vales code, this is to match oral PrEP uptake to Zim target MIHPSA JAS Jul23;
+		end;
+	end;
+	* All vaginal ring PrEP options;
+	if option in (19 20 21 22) then do;
+		date_prep_vr_intro=&year_interv;
+		if caldate{t}=&year_interv then do;
+			pref_prep_vr_beta_s1=pref_prep_oral_beta_s1*3;			* MIHPSA: can adjust this to match vr PrEP uptake to oral PrEP target JAS Jul23;
+		end;
+	end;
+	* All injectable PrEP options;
+	if option in (23 24 25 26) then do;
+		date_prep_inj_intro=&year_interv;
+		if caldate{t}=&year_interv then do;
+			pref_prep_inj_beta_s1=pref_prep_oral_beta_s1*3; 		* MIHPSA: can adjust this to match inj PrEP uptake to oral PrEP target JAS Jul23;
+		end;
+	end;
+
+	* Oral PrEP; 	
+	*option 15: Oral TDF/FTC PrEP for AGYW;
+	if option = 15 then do;
+		*Following values need to change;
+		eff_rate_test_startprep_any=0.4;
+		eff_prob_prep_oral_b=0.9;
+		eff_rate_choose_stop_prep_oral=0.01;
+		eff_prob_prep_any_restart_choice=0.5;	
+	end;
+
+	*option 16: Oral TDF/FTC PrEP for FSW;
+	if option = 16 then do;	
+		eff_rate_test_startprep_any=0.4;
+		eff_prob_prep_oral_b=0.4;
+		eff_rate_choose_stop_prep_oral=0.01;
+		eff_prob_prep_any_restart_choice=0.5;	
+	end;
+
+	*option 17: Oral TDF/FTC PrEP for sero-discordant couples (SDC);
+	if option = 17 then do;
+		eff_rate_test_startprep_any=0.4;
+		eff_prob_prep_oral_b=0.4;
+		eff_rate_choose_stop_prep_oral=0.01;
+		eff_prob_prep_any_restart_choice=0.5;	
+	end;
+
+	*option 18: Oral TDF/FTC PrEP for pregnant and breastfeeding women (PLW);
+	if option = 18 then do;
+		eff_rate_test_startprep_any=0.2;
+		eff_prob_prep_oral_b=0.9;
+		eff_rate_choose_stop_prep_oral=0.01;
+		eff_prob_prep_any_restart_choice=0.5;	
+	end;
+
+	* Dapivirine ring; 
+	*option 19: Dapivirine ring for AGYW;
+	if option = 19 then do;
+		eff_rate_test_startprep_any=0.4;
+		eff_prob_prep_vr_b=0.9;
+		eff_rate_choose_stop_prep_vr=0.01;
+		eff_prob_prep_any_restart_choice=0.5;	
+	end;
+
+	*option 20: Dapivirine ring for FSW;
+	if option = 20 then do;
+		eff_rate_test_startprep_any=0.6;
+		eff_prob_prep_vr_b=0.6;
+		eff_rate_choose_stop_prep_vr=0.01;
+		eff_prob_prep_any_restart_choice=0.5;	
+	end;
+
+	*option 21: Dapivirine ring for SDC;
+	if option = 21 then do;
+		eff_rate_test_startprep_any=0.6;
+		eff_prob_prep_vr_b=0.6;
+		eff_rate_choose_stop_prep_vr=0.01;
+		eff_prob_prep_any_restart_choice=0.5;	
+	end;
+
+	*option 22: Dapivirine ring for PLW;
+	if option = 22 then do;
+		eff_rate_test_startprep_any=0.2;
+		eff_prob_prep_vr_b=0.9;
+		eff_rate_choose_stop_prep_vr=0.01;
+		eff_prob_prep_any_restart_choice=0.5;	
+	end;
+
+	* Injectable PrEP; 
+	*option 23: Injectable PrEP for AGYW;
+	if option = 23 then do;
+		eff_rate_test_startprep_any=0.4;
+		eff_prob_prep_inj_b=0.9;
+		eff_rate_choose_stop_prep_inj=0.01;
+		eff_prob_prep_any_restart_choice=0.5;		
+	end;
+
+	*option 24: Injectable PrEP for FSW;
+	if option = 24 then do;
+		eff_rate_test_startprep_any=0.4;
+		eff_prob_prep_inj_b=0.4;
+		eff_rate_choose_stop_prep_inj=0.01;
+		eff_prob_prep_any_restart_choice=0.5;	
+	end;
+
+	*option 25: Injectable PrEP for SDC;
+	if option = 25 then do;
+		eff_rate_test_startprep_any=0.4;
+		eff_prob_prep_inj_b=0.4;
+		eff_rate_choose_stop_prep_inj=0.01;
+		eff_prob_prep_any_restart_choice=0.5;	
+	end;
+
+	*option 26: Injectable PrEP for PLW;
+	if option = 26 then do;
+		eff_rate_test_startprep_any=0.2;
+		eff_prob_prep_inj_b=0.9;
+		eff_rate_choose_stop_prep_inj=0.01;
+		eff_prob_prep_any_restart_choice=0.5;	
+	end;	
+
+
+	*Linkage, management, ART Interv;
+	*The option "CD4 at initiation, re-initiation and treatment failure to identify AHD and cotrimoxazole in people with CD4 less than 350 or to everyone if no CD4 available" has been removed,
+	as cotrimoxazole is part of the essential;
+	if option = 31 then do;*CD4 at initiation and re-initiation + Screening for Cryptococcal disease when CD4 is <200 cells/ml. if positive in blood and negative in cerebral spinal fluid (CSF) they give preventive treatment (fluconozale), if positive on both they are treated;
+		absence_cd4_year_i = 0; crag_cd4_l200=1;											  
+	end;
+	if option = 32 then do;*CD4 at initiation and re-initiation+ TBLAM when CD4 is <200 or clical stage 3 o 4;
+		absence_cd4_year_i = 0; tblam_cd4_l200=1;										  
+	end;
+	if option = 33 then do;*VL monitoring (6m,1y,2y,3y,etc);
+		absence_vl_year_i = 0;					   
+	end;
+	if option = 34 then do; * poc vl monitoring ;
+		absence_vl_year_i = 0; poc_vl_monitoring_i = 1 ;
+	end;
+
+	*Structural interventions and social enablers;
+	if option = 40 then do;*DREAMS;
+	end;
+
+end;
+
+
 
 *  ======================================================================================================================================== ;
 
@@ -4612,7 +4895,37 @@ and ((testing_disrup_covid ne 1 or covid_disrup_affected ne 1 )) then do;
 	end;
 
 
-	a=rand('uniform');
+	* SELF-TESTING;
+
+	eff_self_test_targeting = self_test_targeting;
+
+	w = rand('uniform');	
+	if hard_reach=0 or (hard_reach = 1 and w < prob_self_test_hard_reach) then do;
+
+		u_self_test=rand('uniform');
+ 		if . < np_lasttest <= 0 then u_self_test = u_self_test * eff_self_test_targeting;  
+		if newp_lasttest ge 1 then u_self_test=u_self_test/eff_self_test_targeting;  
+		if secondary_self_test=1 and eponart=1 then u_self_test=u_self_test/secondary_self_test_targeting;  
+		if tested ne 1 and (caldate{t]-max(0,dt_last_self_test) >= 0.25) and u_self_test < rate_self_test then do;
+			self_tested=1; 
+			dt_last_self_test=caldate{t}; 
+		end;
+	end;
+
+	v = rand('uniform'); z = rand('uniform');
+	if self_tested = 1 and hiv = 1 and z < prob_pos_self_test_conf and v < self_test_sens then do; 
+	tested=1; tested_due_to_self_test=1;
+	dt_last_test=caldate{t}; ever_tested=1; 	np_lasttest=0; newp_lasttest_tested_this_per=newp_lasttest; newp_lasttest=0;
+	end;
+	* note this depends on primary infection lasting 3 months - ts1m ;
+
+
+
+
+
+* TESTING IN RELATION TO PrEP;
+
+a=rand('uniform');
 
 	if t ge 4 and caldate{t} ge min(date_prep_oral_intro, date_prep_inj_intro, date_prep_vr_intro) and hard_reach=0 and 
 	((testing_disrup_covid ne 1 or covid_disrup_affected ne 1)) and (pop_wide_tld_prep ne 1 or (pop_wide_tld_prep=1 and a < prob_test_pop_wide_tld_prep))  
@@ -7625,6 +7938,8 @@ if tested=1 and registd_tm1 ne 1 and prep_falseneg ne 1 then do;	*V*hiv(t)=1 is 
 *	if cost_test=0 then cost_test= cost_test_c;
 * end;
 end;
+
+if registd=1 and registd_tm1=0 and self_tested=1 then diagnosed_self_test = 1;
 
 
 * AP 22-7-19;
@@ -14620,6 +14935,8 @@ if 2 <= caldate&j - infection < 3 and registd_tm1 ne 1 then do; year_3_infection
 if 3 <= caldate&j - infection < 4 and registd_tm1 ne 1 then do; year_4_infection=1; if date1pos=caldate&j then year_4_infection_diag=1;  end;
 if 4 <= caldate&j - infection < 5 and registd_tm1 ne 1 then do; year_5_infection=1; if date1pos=caldate&j then year_5_infection_diag=1;  end;
 
+self_tested_m=0; if gender=1 and self_tested=1 then self_tested_m=1;
+self_tested_w=0; if gender=2 and self_tested=1 then self_tested_w=1;
 
 
 ***Pregnancy outcomes;
@@ -16730,6 +17047,9 @@ if 15 <= age      and (death = . or caldate&j = death ) then do;
  	s_diag_age1564 + diag_age1564; s_diag_m_age1564 + diag_m_age1564; s_diag_w_age1564 + diag_w_age1564 ;  
 	s_hard_reach + hard_reach;  s_tested_at_return + tested_at_return;  s_test_not_costed + test_not_costed;
 
+	s_self_tested + self_tested;  s_tested_due_to_self_test + tested_due_to_self_test;  s_diagnosed_self_test + diagnosed_self_test;
+	s_self_tested_m + self_tested_m ; s_self_tested_w + self_tested_w ;
+
 	/*VL and CD4*/
 
 	s_vlg1 + vlg1 ; s_vlg2 + vlg2 ; s_vlg3 + vlg3 ; s_vlg4 + vlg4 ; s_vlg5 + vlg5 ; s_vlg6 + vlg6 ; 
@@ -18497,6 +18817,7 @@ s_year_1_infection_diag  s_year_2_infection_diag  s_year_3_infection_diag  s_yea
 s_not_on_art_cd4l50 s_not_on_art_cd4l200  s_not_on_art_cd4200350 s_not_on_art_cd4350500 s_not_on_art_cd4ge500  
 s_asympt_Undiag s_asympt_diagoffart s_asympt_diagonart s_sympt_notaids s_sympt_aids 
 s_diag_age1564  s_diag_m_age1564  s_diag_w_age1564  s_hard_reach s_tested_at_return   s_test_not_costed
+s_self_tested s_self_tested_m s_self_tested_w s_tested_due_to_self_test s_diagnosed_self_test
 
 
 /*VL and CD4*/
@@ -18827,6 +19148,7 @@ sw_art_disadv  zero_3tc_activity_m184  zero_tdf_activity_k65r  lower_future_art_
 rate_tb_proph_init rate_sbi_proph_init death_r_iris_pop_wide_tld
 prep_any_strategy prob_prep_any_visit_counsel rate_test_onprep_any prep_dependent_prev_vg1000  prep_vlg1000_threshold rr_mort_tdf_prep
 rate_test_startprep_any  prob_prep_any_restart_choice rel_prep_oral_adh_younger
+prob_self_test_hard_reach self_test_targeting rate_self_test self_test_sens prob_pos_self_test_conf secondary_dist_self_test secondary_self_test_targeting
 
 prep_oral_efficacy higher_future_prep_oral_cov prob_prep_inj_b prob_prep_vr_b prep_inj_efficacy  prop_pep  pep_efficacy 
 rate_choose_stop_prep_inj rate_choose_stop_prep_vr prep_inj_effect_inm_partner pref_prep_inj_beta_s1 incr_res_risk_cab_inf_3m rr_testing_female
@@ -18958,6 +19280,32 @@ keep_going_1999   keep_going_2004   keep_going_2016   keep_going_2020
 
 ;
 
+***Malawi specific;			*JAS Feb24;
+if country = 'Malawi' then do;
+	if cald = 1998.5 and (prevalence1549 < 0.08  or prevalence1549 > 0.19 ) then do; abort abend; end;
+	if cald = 1999.5 and (prevalence1549 < 0.08  or prevalence1549 > 0.19 ) then do; abort abend; end;
+	if cald = 2004.5 and (prevalence1549 < 0.07  or prevalence1549 > 0.20 ) then do; abort abend; end;
+	if cald = 2016.5 and (prevalence1549 < 0.07  or prevalence1549 > 0.13 ) then do; abort abend; end;
+	if cald = 2020 and p_vl1000 < 0.75 then do; abort abend; end;
+end;
+
+***South Africa specific;	*JAS Feb24;
+if country = 'South Africa' then do;
+	if cald = 2017.5 and (prevalence1549 < 0.166 or prevalence1549 > 0.246) then do;
+	  abort abend;
+	end;
+	if cald = 2021 and (s_onart < 3333 or s_onart > 6400) then do;
+	  abort abend;
+	end;
+end;
+
+***Zim specific;			*JAS Feb24;
+if country = 'Zimbabwe' then do;
+	if cald = 1999.5 and (prevalence1549 < 0.08) then do; abort abend; end;
+	if cald = 2004.5 and (prevalence1549 < 0.07) then do; abort abend; end;
+	if cald = 2015.5 and (prevalence1549 < 0.12  or prevalence1549 > 0.15 ) then do; abort abend; end;*ZIMPHIA 13.4;
+end;
+/*if cald = &year_interv and (prevalence1549 > 0.30  or incidence1549 < 0.15 ) then do; abort abend; end;*/	*QUERY should we be using this line for Zim? JAS Feb24;
 
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
@@ -19438,6 +19786,7 @@ s_year_1_infection_diag  s_year_2_infection_diag  s_year_3_infection_diag  s_yea
 s_not_on_art_cd4l50 s_not_on_art_cd4l200  s_not_on_art_cd4200350 s_not_on_art_cd4350500 s_not_on_art_cd4ge500
 s_asympt_Undiag s_asympt_diagoffart s_asympt_diagonart s_sympt_notaids s_sympt_aids 
 s_diag_age1564  s_diag_m_age1564  s_diag_w_age1564   s_hard_reach s_tested_at_return   s_test_not_costed
+s_self_tested s_self_tested_m s_self_tested_w s_tested_due_to_self_test s_diagnosed_self_test
 
 
 /*VL and CD4*/
@@ -20416,6 +20765,7 @@ s_year_1_infection_diag  s_year_2_infection_diag  s_year_3_infection_diag  s_yea
 s_not_on_art_cd4l50 s_not_on_art_cd4l200  s_not_on_art_cd4200350  s_not_on_art_cd4350500  s_not_on_art_cd4ge500
 s_asympt_Undiag s_asympt_diagoffart s_asympt_diagonart s_sympt_notaids s_sympt_aids 
 s_diag_age1564  s_diag_m_age1564  s_diag_w_age1564    s_hard_reach s_tested_at_return  s_test_not_costed
+s_self_tested s_self_tested_m s_self_tested_w s_tested_due_to_self_test s_diagnosed_self_test
 
 /*VL and CD4*/
 s_vlg1  s_vlg2  s_vlg3  s_vlg4  s_vlg5  s_vlg6
@@ -20745,6 +21095,8 @@ zero_3tc_activity_m184  zero_tdf_activity_k65r lower_future_art_cov  higher_futu
 rate_tb_proph_init rate_sbi_proph_init 
 prep_any_strategy  prob_prep_any_visit_counsel rate_test_onprep_any prep_dependent_prev_vg1000 prep_vlg1000_threshold rr_mort_tdf_prep
 prob_prep_any_restart_choice rel_prep_oral_adh_younger
+prob_self_test_hard_reach self_test_targeting rate_self_test self_test_sens prob_pos_self_test_conf secondary_dist_self_test secondary_self_test_targeting
+
 prep_oral_efficacy higher_future_prep_oral_cov prob_prep_inj_b prob_prep_vr_b prep_inj_efficacy   prop_pep  pep_efficacy 
 rate_choose_stop_prep_inj rate_choose_stop_prep_vr prep_inj_effect_inm_partner pref_prep_inj_beta_s1 incr_res_risk_cab_inf_3m rr_testing_female prob_prep_pop_wide_tld
 inc_oral_prep_pref_pop_wide_tld pop_wide_tld prob_test_pop_wide_tld_prep pop_wide_tld_selective_hiv  res_level_dol_cab_mut super_inf_res  


### PR DESCRIPTION
The MIHPSA options code and self-testing sections have been removed from core so this PR is putting them back in. It would be good to go through it together and double check if any other recent changes are missing. Thanks. 